### PR TITLE
Add mongoid 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ bundler_args: --without development
 rvm:
   - 2.0.0
   - 2.1.1
-  - 2.2
+  - 2.2.2
 
 gemfile:
   - Gemfile
   - gemfiles/mongoid4.gemfile
+  - gemfiles/mongoid6.gemfile
 
 env:
   global:
@@ -18,6 +19,13 @@ env:
   matrix:
     - MONGODB=2.4.14
     - MONGODB=2.6.10
+
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      gemfile: gemfiles/mongoid6.gemfile
+    - rvm: 2.1.1
+      gemfile: gemfiles/mongoid6.gemfile
 
 before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz

--- a/gemfiles/mongoid6.gemfile
+++ b/gemfiles/mongoid6.gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'bundler'
+gem 'rake'
+gem 'pry'
+gem 'mongoid', github: 'mongodb/mongoid', ref: '7c2ff52a0c5292b8e6bf3a9a29bbb19abae3dd5f'
+
+group :test do
+  gem 'rspec-given', '~> 3.5'
+  gem 'codeclimate-test-reporter', require: nil
+end
+
+group :doc do
+  gem 'yard'
+  gem 'yard-tomdoc'
+end

--- a/mongoid_includes.gemspec
+++ b/mongoid_includes.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w(CHANGELOG.md LICENSE.txt README.md Rakefile)
   s.test_files   = Dir.glob('spec/**/*')
 
-  s.add_runtime_dependency 'mongoid', ['>= 4.0.0', '< 6.0.0']
+  s.add_runtime_dependency 'mongoid', ['>= 4.0.0', '< 7.0.0']
 end

--- a/spec/support/models/game.rb
+++ b/spec/support/models/game.rb
@@ -6,7 +6,12 @@ class Game
   field :name
 
   belongs_to :person, index: true, validate: true
-  belongs_to :parent, class_name: "Game", foreign_key: "parent-id"
+
+  if Mongoid::VERSION >= "6.0.0"
+    belongs_to :parent, class_name: "Game", foreign_key: "parent-id", optional: true
+  else
+    belongs_to :parent, class_name: "Game", foreign_key: "parent-id"
+  end
 
   accepts_nested_attributes_for :person
 


### PR DESCRIPTION
This PR updates the gemspec such that mongoid 6 is allowed, which will be required for Rails 5. There should be no incompatible changes for this gem.