### PR TITLE
Fix nested self-referencing eager loading

### DIFF
--- a/lib/mongoid/includes/criteria.rb
+++ b/lib/mongoid/includes/criteria.rb
@@ -60,7 +60,7 @@ module Mongoid
         unless metadata = owner_class.reflect_on_association(relation)
           raise Mongoid::Includes::Errors::InvalidIncludes.new(owner_class, relation, options)
         end
-        inclusions.include?(metadata) || inclusions.push(metadata, options)
+        inclusions.push(metadata, options)
       end
     end
   end

--- a/lib/mongoid/includes/inclusion.rb
+++ b/lib/mongoid/includes/inclusion.rb
@@ -17,6 +17,12 @@ module Mongoid
         !!from
       end
 
+      # Public: Checks if the collection already has an inclusion with the
+      # specified metadata.
+      def eql?(other)
+        metadata == other && other.respond_to?(:from) && from == other.from
+      end
+
       # Public: Returns true if the relation is a polymorphic belongs_to.
       def polymorphic_belongs_to?
         metadata.polymorphic? && metadata.relation == Mongoid::Relations::Referenced::In

--- a/lib/mongoid/includes/inclusion.rb
+++ b/lib/mongoid/includes/inclusion.rb
@@ -20,7 +20,7 @@ module Mongoid
       # Public: Checks if the collection already has an inclusion with the
       # specified metadata.
       def eql?(other)
-        metadata == other && other.respond_to?(:from) && from == other.from
+        metadata == other && (!other.respond_to?(:from) || from == other.from)
       end
 
       # Public: Returns true if the relation is a polymorphic belongs_to.

--- a/lib/mongoid/includes/inclusions.rb
+++ b/lib/mongoid/includes/inclusions.rb
@@ -20,12 +20,6 @@ module Mongoid
         metadata
       end
 
-      # Public: Checks if the collection already has an inclusion with the
-      # specified metadata.
-      def include?(metadata)
-        find { |inclusion| inclusion.metadata == metadata }
-      end
-
       # Public: Returns the sum of the inclusions without any duplicates.
       def +(inclusions)
         Inclusions.new(union(inclusions))

--- a/spec/mongoid/includes/inclusions_spec.rb
+++ b/spec/mongoid/includes/inclusions_spec.rb
@@ -19,5 +19,12 @@ describe Mongoid::Includes::Inclusions do
       Then { result.size == 3 }
       And  { result.class == Mongoid::Includes::Inclusions }
     end
+
+    context 'prevents duplicates' do
+      Given {
+        inclusions.add(Band.relations['albums'])
+      }
+      Then { inclusions.size == 3 }
+    end
   end
 end

--- a/spec/mongoid/includes/nested_inclusions_spec.rb
+++ b/spec/mongoid/includes/nested_inclusions_spec.rb
@@ -48,5 +48,19 @@ describe Mongoid::Includes::Criteria do
       And  { inclusions.to_a[1].nested? && !inclusions.to_a[1].polymorphic_belongs_to? }
       And  { inclusions.to_a[2].nested? && inclusions.to_a[2].polymorphic_belongs_to? }
     end
+
+    context 'works with self-referencing relations' do
+      Given(:metadata) { Node.relations['children'] }
+
+      When(:criteria) {
+        Node.includes(:children, from: :children)
+      }
+
+      Then { inclusions.size == 2 }
+      And  { expect(inclusions.to_a[0].metadata).to eq(metadata) }
+      And  { expect(inclusions.to_a[0].from).to be_nil }
+      And  { expect(inclusions.to_a[1].metadata).to eq(metadata) }
+      And  { expect(inclusions.to_a[1].from).to eq(:children) }
+    end
   end
 end

--- a/spec/support/models/node.rb
+++ b/spec/support/models/node.rb
@@ -1,0 +1,6 @@
+class Node
+  include Mongoid::Document
+
+  has_and_belongs_to_many :parents, class_name: 'Node', inverse_of: :children
+  has_and_belongs_to_many :children, class_name: 'Node', inverse_of: :parents
+end


### PR DESCRIPTION
Hi @ElMassimo 

This pull request fixes a problem when trying to eager load nested models on a relation that is the same as the parent relation. This happens when using circular relations (with inclusion in the form of `criteria.includes(:albums, from: :albums)`). I fixed that by making inclusions unique in the scope of the `from` option.