### PR TITLE
Remove local Bundler config, ignore .bundle/

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_WITHOUT: "development"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ spec/mongo.log
 
 coverage.data/
 coverage/
+
+.bundle/


### PR DESCRIPTION
Remove committed local Bundler config and ignore .bundle/ to avoid forcing BUNDLE_WITHOUT.

This was breaking ruby-lsp, provided no benefit that I can see (it was added [here](https://github.com/cacheventures/mongoid_includes/commit/76564dfa7aadfbce25604546b38e10b2eda0abf6)), and it [shouldn't be in the project](https://github.com/rubygems/bundler/issues/4523#issuecomment-216694527).